### PR TITLE
Put Pactas data in configuration file.

### DIFF
--- a/app/utils/pactas/Pactas.java
+++ b/app/utils/pactas/Pactas.java
@@ -3,16 +3,17 @@ package utils.pactas;
 import com.ning.http.client.Realm;
 import org.codehaus.jackson.JsonNode;
 import org.codehaus.jackson.node.ObjectNode;
+import play.Play;
 import play.libs.F;
 import play.libs.Json;
 import play.libs.WS;
 
 public class Pactas {
 
-    protected static String API_URL = "https://sandbox.pactas.com/api/v1/";
-    private static String AUTH_URL = "https://sandbox.pactas.com/oauth/token/";
-    private static String CLIENT_ID = "523075921d8dd007f822edaa";
-    private static String CLIENT_SECRET = "332324095c5c665bd4bc680eb98739e1";
+    protected static String API_URL = Play.application().configuration().getString("pactas.api");
+    private static String AUTH_URL = Play.application().configuration().getString("pactas.auth");
+    private static String CLIENT_ID = Play.application().configuration().getString("pactas.clientId");
+    private static String CLIENT_SECRET = Play.application().configuration().getString("pactas.clientSecret");
 
     protected String access_token;
     protected JsonNode response;

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -11,7 +11,7 @@ application.secret="FIX ME" # http://stackoverflow.com/questions/18989131/how-to
 # ~~~~~
 application.langs="en"
 
-# Sphere
+# SPHERE
 # ~~~~~
 # Configuration of the Sphere SDK
 
@@ -33,6 +33,21 @@ sphere.cart.inventoryMode="None"
 
 # Default locale for searching, faceting, filtering and sorting
 sphere.defaultLocale="en"
+
+
+# PACTAS
+# ~~~~~
+# Configuration of the Pactas account
+
+# Pactas API endpoint:
+pactas.api="https://sandbox.pactas.com/api/v1/"
+
+# Pactas authorization service:
+pactas.auth="https://sandbox.pactas.com/oauth/token/"
+
+# Pactas credentials
+pactas.clientId="523075921d8dd007f822edaa"
+pactas.clientSecret="332324095c5c665bd4bc680eb98739e1"
 
 
 # Logger


### PR DESCRIPTION
@hajoeichler I make a pull request because once merged the documentation will be inconsistent with the code.

So in order to fix it, this line of code should be:
"To change to your Pactas account, modify (client ID -> pactas.clientId) and (client secret -> pactas.clientSecret) (into -> ??) in (app/utils/pactas/Pactas.java -> conf/application.conf)"

The Paymill explanation is also wrong, as the Paymill key is located in the Pactas backend, not in our code:
"To change to your PAYMILL account, enter your public key in (app/views/main.scala.html (line ~52) -> Pactas backend!!)"

Also note the Pactas credentials are exposed.
